### PR TITLE
Add support for empty arrays

### DIFF
--- a/curious/grammar.py
+++ b/curious/grammar.py
@@ -54,7 +54,7 @@ another_arg  = space* "," space* arg
 arg          = arg_name space* "=" space* values
 arg_name     = identifier
 values       = array_value / value
-array_value  = bracket_l space* value another_val* space* bracket_r
+array_value  = bracket_l space* ((value another_val*) / space*) space* bracket_r
 bracket_l    = "[" / "("
 bracket_r    = "]" / ")"
 another_val  = space* "," space* value

--- a/curious/parser.py
+++ b/curious/parser.py
@@ -190,10 +190,14 @@ class ASTBuilder(NodeVisitor):
     return val[0]
 
   def visit_array_value(self, node, args):
-    (br1, _1, value, more_values, _2, br2) = args
-    if type(more_values) != list:
-      more_values = []
-    return [value]+more_values
+    (br1, _1, value_list, _2, br2) = args
+    if type(value_list[0]) == list:
+      [value, more_values] = value_list[0]
+      if type(more_values) != list:
+        more_values = []
+      return [value]+more_values
+    else:
+      return []
 
   def visit_another_val(self, node, args):
     (_1, comma, _2, value) = args

--- a/tests/curious_tests/test_simple_queries.py
+++ b/tests/curious_tests/test_simple_queries.py
@@ -51,6 +51,24 @@ class TestSimpleQueries(TestCase):
     assertQueryResultsEqual(self, result[0][0][0], [(self.entries[0], None)])
     self.assertEquals(result[1], Entry)
 
+  def test_query_with_empty_array_filter(self):
+    qs = 'Entry(id__in=[])'
+    query = Query(qs)
+    result = query()
+    self.assertFalse(result[0][0][0])
+
+  def test_query_with_spaces_only_array_filter(self):
+    qs = 'Entry(id__in=[  ])'
+    query = Query(qs)
+    result = query()
+    self.assertFalse(result[0][0][0])
+
+  def test_query_exlcuding_empty_array_filter(self):
+    qs = 'Entry.exclude(id__in=[])'
+    query = Query(qs)
+    result = query()
+    self.assertEquals(3, len(result[0][0][0]))
+
   def test_query_traversing_to_fk_object(self):
     qs = 'Entry(%s) Entry.blog' % self.entries[0].pk
     query = Query(qs)


### PR DESCRIPTION
This Pull Request extends curious to support queries with empty arrays. For example:

```Entry(id__in=[])```

This is useful for programmatically generated queries.