### PR TITLE
Fix deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 # Packages
 *.egg
 *.egg-info
+.eggs
 dist
 build
 eggs
@@ -38,6 +39,7 @@ htmlcov
 
 # Pycharm/Intellij
 .idea
+Session.vim
 
 # Complexity
 output/*.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,9 @@ tag = True
 [bumpversion:file:setup.py]
 
 [aliases]
-install = build_assets install_bower -R install
-develop = build_assets install_bower -R develop
+install = install_bower -R build_assets install
+develop = install_bower -R build_assets develop
 build = build_assets build
-sdist = build_assets sdist
-bdist_wheel = build_assets bdist_wheel
-bdist_egg = build_assets bdist_egg
+sdist = install_bower -R build_assets sdist
+bdist_wheel = install_bower -R build_assets bdist_wheel
+bdist_egg = install_bower -R build_assets bdist_egg

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,3 @@ build = build_assets build
 sdist = build_assets sdist
 bdist_wheel = build_assets bdist_wheel
 bdist_egg = build_assets bdist_egg
-


### PR DESCRIPTION
Bower assets were getting removed before the package was getting built, preventing it from working correctly when installed in a server.

This PR:
- Makes sure that the bower installation is called before package builds
- Adds output to the bower install command