### PR TITLE
Add back in dereference for remote fks

### DIFF
--- a/curious/related.py
+++ b/curious/related.py
@@ -1,9 +1,12 @@
+from curious import deferred_to_real
 
 def remote_fk(from_model_fk_field, to_model, to_model_field=None):
   to_model_field = 'pk' if to_model_field is None else to_model_field
 
   @staticmethod
   def rel_f(instances, filter_f):
+    instances = deferred_to_real(instances)
+
     c = {}
     c['%s__in' % to_model_field] = [getattr(instance, from_model_fk_field) for instance in instances]
     q = to_model.objects.filter(**c)

--- a/tests/curious_tests/models.py
+++ b/tests/curious_tests/models.py
@@ -47,6 +47,7 @@ class Entry(models.Model):
   headline = models.CharField(max_length=255)
   authors = models.ManyToManyField(Author)
   response_to = models.ForeignKey('self', null=True, related_name='responses')
+  related_blog_id = models.PositiveIntegerField(null=True)
 
   def __unicode__(self):
     return self.headline

--- a/tests/curious_tests/test_api_batch.py
+++ b/tests/curious_tests/test_api_batch.py
@@ -30,11 +30,12 @@ class TestBatchFetch(TestCase):
     r = self.client.post('/curious/models/Entry/', data=json.dumps(data), content_type='application/json')
     self.assertEquals(r.status_code, 200)
     results = json.loads(r.content)['result']
-    self.assertEquals(results['fields'], ["id", "blog_id", "headline", "response_to_id"])
+    self.assertEquals(results['fields'], ["id", "blog_id", "headline", "response_to_id", "related_blog_id"])
     self.assertItemsEqual(results['urls'], [None for e in self.entries])
     self.assertItemsEqual(results['objects'],
                           [[e.id,
                             [self.blog.__class__.__name__, self.blog.pk, self.blog.name, None],
                             e.headline,
+                            None,
                             None]
                            for e in self.entries])

--- a/tests/curious_tests/test_related.py
+++ b/tests/curious_tests/test_related.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, override_settings
+from django.db import connection
+
+import curious_tests.models
+from curious import model_registry
+from curious.related import remote_fk
+from curious.query import Query
+from curious_tests.models import Blog, Entry, Author
+
+
+class TestRelated(TestCase):
+  N = 20
+
+  def setUp(self):
+    self.blog = Blog(name='Databases')
+    self.blog.save()
+
+    self.entries = [Entry(headline='Abc {}'.format(i), blog=self.blog) for i in xrange(self.N)]
+    for index, entry in enumerate(self.entries):
+      if index < len(self.entries) - 1:
+        entry.related_blog_id = self.entries[index + 1].pk
+
+    for entry in self.entries:
+      entry.save()
+
+    self.query_count = len(connection.queries)
+    model_registry.register(curious_tests.models)
+    Blog.entry_ = remote_fk('entry_id', Entry)
+    Entry.related_blog_ = remote_fk('related_blog_id', Entry)
+    model_registry.get_manager('Entry').allowed_relationships = [
+      'related_blog_',
+    ]
+
+  @override_settings(DEBUG=True)
+  def test_reverse_lookup_in_one(self):
+    qs = 'Blog(id={}), Blog.entry_set ?(Entry.related_blog_)'.format(self.blog.pk)
+    query = Query(qs)
+    result = query()
+    self.assertEqual(len(connection.queries) - self.query_count, 4)
+    self.assertEqual(len(result[0][1][0]), self.N)


### PR DESCRIPTION
This adds back the dereference to remote_fk that allows for batch lookups by reverse fks.