### PR TITLE
Add property_fields functionality

### DIFF
--- a/curious/__init__.py
+++ b/curious/__init__.py
@@ -85,6 +85,16 @@ class ModelRegistry(object):
       if not hasattr(model, '_meta') or model._meta.abstract is False:
         self.__add_model_by_class(model, short_name)
 
+  def unregister(self, model_name):
+
+    # will error out if model_name is ambiguious
+    full_model_name = self.__translate_name(model_name)
+
+    del self.__managers[full_model_name]
+
+    # if we get here, we can be sure there's exactly one entry in short_names
+    del self.__short_names[model_name]
+
   def __translate_name(self, name):
     if name in self.__managers:
       model_name = name

--- a/curious/__init__.py
+++ b/curious/__init__.py
@@ -22,11 +22,20 @@ class ModelManager(object):
 
   def __init__(self, model_class, short_name=None):
     self.model_class = model_class
+
     self.model_name = ModelManager.model_name(model_class)
     self.short_name = model_class.__name__ if short_name is None else short_name
+
+    # Relationships/foreign keys have explicit white/blacklists
     self.allowed_relationships = []
     self.disallowed_relationships = []
+
+    # All model fields are included by default, except these
     self.field_excludes = []
+
+    # Fields returned by Curious represented by @properties of the model
+    self.property_fields = []
+
     self.url_function = None
 
   def is_rel_allowed(self, f):
@@ -82,7 +91,7 @@ class ModelRegistry(object):
         ):
           self.__add_model_by_class(cls)
     else:
-      if not hasattr(model, '_meta') or model._meta.abstract is False:
+      if not hasattr(model, '_meta') or not model._meta.abstract:
         self.__add_model_by_class(model, short_name)
 
   def unregister(self, model_name):

--- a/curious/__init__.py
+++ b/curious/__init__.py
@@ -34,7 +34,11 @@ class ModelManager(object):
       rel = getattr(self.model_class, f)
     except:
       rel = None
-    if rel and _valid_django_rel(getattr(self.model_class, f)) and not f in self.disallowed_relationships:
+    if (
+      rel
+      and _valid_django_rel(getattr(self.model_class, f))
+      and f not in self.disallowed_relationships
+    ):
       return True
     return f in self.allowed_relationships
 
@@ -68,10 +72,14 @@ class ModelRegistry(object):
       self.__short_names[manager.short_name].append(manager)
 
   def register(self, model, short_name=None):
-    if type(model) == types.ModuleType:
+    if isinstance(model, types.ModuleType):
       for name in dir(model):
         cls = getattr(model, name)
-        if inspect.isclass(cls) and issubclass(cls, django.db.models.Model) and cls._meta.abstract is False:
+        if (
+          inspect.isclass(cls)
+          and issubclass(cls, django.db.models.Model)
+          and not cls._meta.abstract
+        ):
           self.__add_model_by_class(cls)
     else:
       if not hasattr(model, '_meta') or model._meta.abstract is False:
@@ -106,8 +114,12 @@ class ModelRegistry(object):
     if len(managers) == 0:
       return ModelManager.model_name(cls)
     manager = managers[0]
-    if manager.short_name in self.__short_names and len(self.__short_names[manager.short_name]) == 1:
+    if (
+      manager.short_name in self.__short_names
+      and len(self.__short_names[manager.short_name]) == 1
+    ):
       return manager.short_name
     return manager.model_name
+
 
 model_registry = ModelRegistry()

--- a/curious/api.py
+++ b/curious/api.py
@@ -15,7 +15,7 @@ import time
 
 
 CACHE_VERSION = 5
-CACHE_TIMEOUT = 60*60
+CACHE_TIMEOUT = 60 * 60
 try:
   cache = caches['curious']
 except InvalidCacheBackendError:
@@ -191,7 +191,7 @@ class ModelView(JSONView):
       cls = model_registry.get_manager(model_name).model_class
     except:
       return self._error(404, "Unknown model '%s'" % model_name)
- 
+
     ignore_excludes = get_param_value(data, 'x', False)
     r = ModelView.get_objects_as_json(cls, data['ids'], ignore_excludes, True, True, app)
     return self._return(200, r)
@@ -240,6 +240,7 @@ class ObjectView(JSONView):
 
 
 class QueryView(JSONView):
+
   # if query takes longer than this number of seconds, cache it
   QUERY_TIME_CACHING_THRESHOLD = 10
 
@@ -254,7 +255,7 @@ class QueryView(JSONView):
     if cache_v is None:
       t = time.time()
       cache_v = self.run_query(query)
-      t = time.time()-t
+      t = time.time() - t
 
       if app is not None:
         if t > QueryView.QUERY_TIME_CACHING_THRESHOLD or force_cache:
@@ -284,11 +285,12 @@ class QueryView(JSONView):
       else:
         model_name = None
 
-      d = {'model': model_name,
-           'join_index': join_index,
-           'objects': [(obj.pk, src) if obj is not None else (None, src) for obj, src in obj_src],
-           'tree': tree
-          }
+      d = {
+        'model': model_name,
+        'join_index': join_index,
+        'objects': [(obj.pk, src) if obj is not None else (None, src) for obj, src in obj_src],
+        'tree': tree,
+      }
       results.append(d)
 
     if last_model is not None:
@@ -329,7 +331,7 @@ class QueryView(JSONView):
       traceback.print_exc()
       return self._error(400, str(e))
 
-    t = datetime.now()-results['computed_on']
+    t = datetime.now() - results['computed_on']
     if t.seconds > 300:
       results['computed_since'] = str(naturaltime(results['computed_on']))
     results['computed_on'] = str(results['computed_on'])
@@ -340,7 +342,7 @@ class QueryView(JSONView):
       for result in results['results']:
         if result['model']:
           model = model_registry.get_manager(result['model']).model_class
-          ids = [t[0] for t in result['objects']]
+          ids = [obj[0] for obj in result['objects']]
           objs = ModelView.get_objects_as_json(model, ids, ignore_excludes, follow_fk, force, app)
           objects.append(objs)
         else:

--- a/curious/api.py
+++ b/curious/api.py
@@ -72,20 +72,27 @@ class ModelView(JSONView):
 
     obj = objects[0]
     model_name = model_registry.get_name(obj.__class__)
+    model_manager = model_registry.get_manager(model_name)
     if ignore_excludes is True:
       excludes = []
     else:
-      excludes = model_registry.get_manager(model_name).field_excludes
+      excludes = model_manager.field_excludes
 
     if hasattr(obj, '_meta'):
       for f in obj._meta.fields:
         if f.column not in excludes:
           fields.append(f.column)
           fk.append(f.name if type(f) == ForeignKey else None)
+
       if 'id' not in fields:
         fields.append('pk')
         fk.append(None)
         add_pk = True
+
+      for f in model_manager.property_fields:
+        fields.append(f)
+        fk.append(None)
+
     else:
       is_model = False
       for f in obj.fields():

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,14 @@ sdist = install_bower -R build_assets sdist
 bdist_wheel = install_bower -R build_assets bdist_wheel
 bdist_egg = install_bower -R build_assets bdist_egg
 
+[flake8]
+ignore = E111,E114,E121,E123,E126,E133,E241,W503
+exclude =
+	.git,
+	.tox,
+	__pycache__,
+	build,
+	dist,
+	*migrations*
+max-line-length = 100
+statistics = True

--- a/tests/curious_tests/models.py
+++ b/tests/curious_tests/models.py
@@ -27,8 +27,19 @@ class Blog(models.Model):
     return r
 
 
-class Person(models.Model):
+class LivingThing(models.Model):
+  class Meta:
+    abstract = True
+
+  alive = models.BooleanField(default=True)
+
+
+class Person(LivingThing):
   gender = models.CharField(max_length=50)
+
+  @property
+  def example_property_field(self):
+    return 'The owls are not what they seem'
 
 
 class Author(models.Model):

--- a/tests/curious_tests/test_api_query.py
+++ b/tests/curious_tests/test_api_query.py
@@ -1,10 +1,10 @@
 import json
 from django.test import TestCase
-from django.db import connection
 from curious import model_registry
 from curious.api import ModelView
-from curious_tests.models import Blog, Entry
+from curious_tests.models import Blog, Entry, Person
 import curious_tests.models
+
 
 class TestQueryAPI(TestCase):
   N = 3
@@ -14,10 +14,13 @@ class TestQueryAPI(TestCase):
     blog.save()
     self.blog = blog
 
-    headlines = ['MySQL is a relational DB']*TestQueryAPI.N
+    headlines = ['MySQL is a relational DB'] * TestQueryAPI.N
     self.entries = [Entry(headline=headline, blog=blog) for i, headline in enumerate(headlines)]
     for entry in self.entries:
       entry.save()
+
+    self.person = Person(gender='parrot', alive=False)
+    self.person.save()
 
     # register model
     model_registry.register(curious_tests.models)
@@ -32,7 +35,10 @@ class TestQueryAPI(TestCase):
     self.assertEquals(j.keys(), ['result'])
     self.assertEquals(j['result']['last_model'], 'Entry')
     self.assertEquals(len(j['result']['results']), 1)
-    self.assertItemsEqual(j['result']['results'][0].keys(), ['model', 'join_index', 'objects', 'tree'])
+    self.assertItemsEqual(
+      j['result']['results'][0].keys(),
+      ['model', 'join_index', 'objects', 'tree'],
+    )
     self.assertEquals(j['result']['results'][0]['model'], 'Entry')
     self.assertEquals(j['result']['results'][0]['join_index'], -1)
     objects = [[obj.id, None] for obj in self.entries]
@@ -46,17 +52,23 @@ class TestQueryAPI(TestCase):
     self.assertEquals(j['result']['last_model'], 'Entry')
     self.assertEquals(len(j['result']['results']), 2)
 
-    self.assertItemsEqual(j['result']['results'][0].keys(), ['model', 'join_index', 'objects', 'tree'])
+    self.assertItemsEqual(
+      j['result']['results'][0].keys(),
+      ['model', 'join_index', 'objects', 'tree'],
+    )
     self.assertEquals(j['result']['results'][0]['model'], 'Blog')
     self.assertEquals(j['result']['results'][0]['join_index'], -1)
     self.assertItemsEqual(j['result']['results'][0]['objects'], [[self.blog.pk, None]])
 
-    self.assertItemsEqual(j['result']['results'][1].keys(), ['model', 'join_index', 'objects', 'tree'])
+    self.assertItemsEqual(
+      j['result']['results'][1].keys(),
+      ['model', 'join_index', 'objects', 'tree'],
+    )
     self.assertEquals(j['result']['results'][1]['model'], 'Entry')
     self.assertEquals(j['result']['results'][1]['join_index'], 0)
     objects = [[obj.id, self.blog.pk] for obj in self.entries]
     self.assertItemsEqual(j['result']['results'][1]['objects'], objects)
-  
+
   def test_getting_data_with_query(self):
     r = self.client.get('/curious/q/', dict(d=1, q='Blog(%s), Blog.entry_set' % self.blog.pk))
     self.assertEquals(r.status_code, 200)
@@ -66,12 +78,18 @@ class TestQueryAPI(TestCase):
     self.assertEquals(j['result']['last_model'], 'Entry')
     self.assertEquals(len(j['result']['results']), 2)
 
-    self.assertItemsEqual(j['result']['results'][0].keys(), ['model', 'join_index', 'objects', 'tree'])
+    self.assertItemsEqual(
+      j['result']['results'][0].keys(),
+      ['model', 'join_index', 'objects', 'tree'],
+    )
     self.assertEquals(j['result']['results'][0]['model'], 'Blog')
     self.assertEquals(j['result']['results'][0]['join_index'], -1)
     self.assertItemsEqual(j['result']['results'][0]['objects'], [[self.blog.pk, None]])
 
-    self.assertItemsEqual(j['result']['results'][1].keys(), ['model', 'join_index', 'objects', 'tree'])
+    self.assertItemsEqual(
+      j['result']['results'][1].keys(),
+      ['model', 'join_index', 'objects', 'tree'],
+    )
     self.assertEquals(j['result']['results'][1]['model'], 'Entry')
     self.assertEquals(j['result']['results'][1]['join_index'], 0)
     objects = [[obj.id, self.blog.pk] for obj in self.entries]
@@ -79,4 +97,30 @@ class TestQueryAPI(TestCase):
 
     self.assertItemsEqual(j['result'].keys(), ['last_model', 'results', 'computed_on', 'data'])
     self.assertEquals(j['result']['data'][0], ModelView.objects_to_dict([self.blog]))
-    self.assertEquals(j['result']['data'][1], json.loads(json.dumps(ModelView.objects_to_dict(self.entries))))
+    self.assertEquals(
+      j['result']['data'][1],
+      json.loads(json.dumps(ModelView.objects_to_dict(self.entries))),
+    )
+
+  def test_property_fields(self):
+    person_manager = model_registry.get_manager('Person')
+    person_manager.property_fields = [
+      'example_property_field',
+    ]
+
+    r = self.client.post(
+      '/curious/q/',
+      data=json.dumps({'q': 'Person({0.pk})'.format(self.person), 'd': 1}),
+      content_type='application/json',
+    )
+    self.assertEquals(r.status_code, 200)
+    result = json.loads(r.content)['result']
+    print result
+    data = json.loads(r.content)['result']['data'][0]
+    self.assertItemsEqual(data['fields'], ['id', 'alive', 'example_property_field', 'gender'])
+    self.assertItemsEqual(data['objects'][0], [
+      self.person.pk,
+      self.person.alive,
+      self.person.example_property_field,
+      self.person.gender,
+    ])

--- a/tests/curious_tests/test_managers.py
+++ b/tests/curious_tests/test_managers.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from curious import ModelRegistry
+
+from curious_tests import models
+
+
+class TestModelRegistry(TestCase):
+
+  def setUp(self):
+    self.model_registry = ModelRegistry()
+
+  def tearDown(self):
+    self.model_registry.clear()
+    del self.model_registry
+
+  def test_register(self):
+    self.model_registry.register(models.Person)
+
+    self.assertEqual([['curious_tests__Person']], [self.model_registry.model_names])
+
+  def test_register_abstract(self):
+    self.model_registry.register(models.Person)
+    self.model_registry.register(models.LivingThing)
+
+    self.assertEqual([['curious_tests__Person']], [self.model_registry.model_names])
+
+  def test_unregister(self):
+    self.model_registry.register(models.Person)
+    self.model_registry.unregister('Person')
+    self.assertEqual([[]], [self.model_registry.model_names])


### PR DESCRIPTION
Allows you to define `property_fields` on a model manager to point to `@property` desxcriptors on a Django model that will be returned along with the query as if they were regular fields.

Also:
- adds model-specific `unregister` method to the manager
- adds unit tests for all functionality

For internal Ginkgo context, see [BC-430](https://ginkgobioworks.atlassian.net/browse/BC-430)