### PR TITLE
Support counting of related objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,27 @@ Example
 Query Language
 --------------
 
-avg, sum, max, count. ? modifier for left joins. t modifier for dates.
+The query language allows traversing models by identfying the relationships between them,
+through foreign keys in Django models, or arbitrary id-mapping functions. A Curious query
+is a space-separated set of terms, which connect models together by relationships.
+
+Several kinds of "joins" are possible using these relationship primitives:
+
+- A traditional `inner join` ``Book Book.author_set``
+- A `left outer join`: ``Book.last(10) ?(Book.author_set)``
+- A `recusrive join`: ``Parent.children_*``
+
+Furthermore, at each stage in a join, `filtering` can happen:
+
+- Filtering by `Django field lookups`_: ``Book Book.author_set(id__in=[2,3,4])``
+- Filtering by `subquery`: ``Book +(Book.author_set(id__in=[2,3,4]))``
+- Filtering by `exclusive subquery` ``Book -(Book.author_set(id__in=[2,3,4]))``
+
+Finally, relationships can generate `counts`:
+
+- Counting ``Book Book.author_set__count``
+
+.. _Django field lookups: https://docs.djangoproject.com/en/1.11/ref/models/querysets/#field-lookups
 
 Configuring Curious
 -------------------

--- a/curious/__init__.py
+++ b/curious/__init__.py
@@ -2,7 +2,7 @@ import inspect
 import types
 import django.db.models
 from .graph import _valid_django_rel
-from .graph import traverse
+from . import count
 
 
 def deferred_to_real(objs):
@@ -11,61 +11,6 @@ def deferred_to_real(objs):
     return []
   model = deferred_model[0]
   return model.objects.filter(pk__in=[obj.pk for obj in objs])
-
-
-class CountObject(object):
-
-  def __init__(self, id):
-    try:
-      self.__value = int(id)
-    except:
-      self.__value = None
-
-  def __str__(self):
-    return '%s' % self.__value
-
-  @classmethod
-  def fetch(cls, ids):
-    return cls.query(ids)
-
-  @classmethod
-  def query(cls, ids):
-    objs = [cls(id) for id in ids]
-    return objs
-
-  @property
-  def value(self):
-    return self.__value
-
-  @property
-  def id(self):
-    return self.__value
-
-  @property
-  def pk(self):
-    return self.id
-
-  def fields(self):
-    return ['id', 'value']
-
-  def get(self, f):
-    if f == 'id':
-      return self.id
-    elif f == 'value':
-      return self.value
-    return None
-
-  @staticmethod
-  def count_wrapper(f):
-    def wrapped(objs, filters):
-      rels = traverse(objs, f, filters=filters)
-      counts = {}
-      for target,src_id in rels:
-        if src_id not in counts:
-          counts[src_id] = {}
-        counts[src_id][target.pk] = 1
-      return [(CountObject(len(targets.keys())),src_id) for src_id,targets in counts.iteritems()]
-    return wrapped
 
 
 class ModelManager(object):
@@ -95,10 +40,8 @@ class ModelManager(object):
     self.url_function = None
 
   def is_rel_allowed(self, f):
-    try:
-      rel = getattr(self.model_class, f)
-    except:
-      rel = None
+    rel = getattr(self.model_class, f, None)
+
     if (
       rel
       and _valid_django_rel(getattr(self.model_class, f))
@@ -116,7 +59,7 @@ class ModelManager(object):
     if method.endswith("__count"):
       method = method[:-7]
       f = self.getattr(method)
-      return CountObject.count_wrapper(f)
+      return count.CountObject.count_wrapper(f)
 
     if not hasattr(self.model_class, method):
       raise Exception('Unknown attribute "%s" in "%s"' % (method, self.model_name))
@@ -229,4 +172,4 @@ class ModelRegistry(object):
     return manager.model_name
 
 
-model_registry = ModelRegistry(special_models=(CountObject,))
+model_registry = ModelRegistry(special_models=(count.CountObject,))

--- a/curious/__init__.py
+++ b/curious/__init__.py
@@ -126,12 +126,39 @@ class ModelManager(object):
 
 
 class ModelRegistry(object):
-  def __init__(self):
+
+  def __init__(self, special_models=None):
+    """
+    Create a new model registry
+
+    Optionally determine "special" models that don't get cleared by default.
+
+    Parameters
+    ----------
+    special_models : iterable, optional
+      An iterable of models to register as "special": won't be cleared by a regular call
+      to :meth:`~.clear`
+    """
+    self.__special_models = special_models
     self.clear()
 
-  def clear(self):
+  def clear(self, force=False):
+    """
+    Unregister all models, optionally including special ones
+
+    Parameters
+    ----------
+    force : bool
+      True if special models should also be deleted
+    """
     self.__managers = {}
     self.__short_names = {}
+
+    if force:
+      self.__special_models = None
+    elif self.__special_models is not None:
+      for model in self.__special_models:
+        self.register(model)
 
   def __add_model_by_class(self, cls, short_name=None):
     manager = ModelManager(cls, short_name)
@@ -202,5 +229,4 @@ class ModelRegistry(object):
     return manager.model_name
 
 
-model_registry = ModelRegistry()
-model_registry.register(CountObject)
+model_registry = ModelRegistry(special_models=(CountObject,))

--- a/curious/count.py
+++ b/curious/count.py
@@ -1,0 +1,127 @@
+from collections import defaultdict
+from functools import wraps
+
+from .graph import traverse
+
+
+class CountObject(object):
+  """
+  A virtual model representing the result of a `__count` expression
+  """
+  def __init__(self, pk):
+    try:
+      self.__value = int(pk)
+    except (TypeError, ValueError):
+      self.__value = None
+
+  def __str__(self):
+    return '%s' % self.__value
+
+  @classmethod
+  def fetch(cls, pks):
+    """
+    Mock up "fetching" a CountObject
+
+    Necessary for the custom model API (see :mod:`test_custom_model` for an example)
+
+    Parameters
+    ----------
+    pks : list of int
+      Primary keys to "get" equal to the value of the count
+
+    Returns
+    -------
+    list of CountObjects
+      A list of new CountObject instances with the corresponding counts
+    """
+    return [cls(pk) for pk in pks]
+
+  @property
+  def value(self):
+    """ The value the count represents """
+    return self.__value
+
+  @property
+  def pk(self):
+    """
+    A mock of the primary key
+
+    Necessary for the custom model API (see :mod:`test_custom_model` for an example). Equivalent
+    to the value
+    """
+    return self.__value
+
+  @property
+  def id(self):
+    """
+    Aliased to :obj:`~self.pk`
+    """
+    return self.pk
+
+  def fields(self):
+    """
+    List the fields the object returns
+
+    Necessary for the custom model API (see :mod:`test_custom_model` for an example).
+
+    Returns
+    -------
+    list of str
+      A list of field names
+    """
+    return ['id', 'value']
+
+  def get(self, field_name):
+    """
+    Get the value of an object field by name.
+
+    Necessary for the custom model API (see :mod:`test_custom_model` for an example).
+
+    Parameters
+    ----------
+    field_name : str
+      The name of a field to get
+
+    Returns
+    -------
+    object
+      The object's value of `field_name`.
+    """
+    return getattr(self, field_name, None)
+
+  @staticmethod
+  def count_wrapper(relationship_function):
+    """
+    A decorator that turns a regular relationship into a count relationship
+
+    This method is the workhorse of :class:`CountObject`. It takes a typical "relationship function"
+    that gets you from one model to another, and turns it into a "count relationship function" that,
+    instead of returning objects of the next model type, returns virtual :class:`CountObject`
+    instances which hold the number of items that the relationship function would have returned.
+
+    Parameters
+    ----------
+    relationship_function : callable
+      A function that takes a list of IDs
+
+    Returns
+    -------
+    object
+      The object's value of `field_name`.
+    """
+
+    @wraps(relationship_function)
+    def wrapped(objs, filters=None):
+      rels = traverse(objs, relationship_function, filters=filters)
+
+      # Uniquely count relations, grouped by source object
+      counts = defaultdict(set)
+      for target, src_pk in rels:
+        counts[src_pk].add(target.pk)
+
+      return [
+        (CountObject(len(targets)), src_pk)
+        for src_pk, targets in counts.iteritems()
+      ]
+
+    return wrapped

--- a/curious/count.py
+++ b/curious/count.py
@@ -1,3 +1,4 @@
+import types
 from collections import defaultdict
 from functools import wraps
 
@@ -90,7 +91,7 @@ class CountObject(object):
     return getattr(self, field_name, None)
 
   @staticmethod
-  def count_wrapper(relationship_function):
+  def count_wrapper(relationship):
     """
     A decorator that turns a regular relationship into a count relationship
 
@@ -101,7 +102,7 @@ class CountObject(object):
 
     Parameters
     ----------
-    relationship_function : callable
+    relationship : callable
       A function that takes a list of IDs
 
     Returns
@@ -110,9 +111,8 @@ class CountObject(object):
       The object's value of `field_name`.
     """
 
-    @wraps(relationship_function)
     def wrapped(objs, filters=None):
-      rels = traverse(objs, relationship_function, filters=filters)
+      rels = traverse(objs, relationship, filters=filters)
 
       # Uniquely count relations, grouped by source object
       counts = defaultdict(set)
@@ -123,5 +123,8 @@ class CountObject(object):
         (CountObject(len(targets)), src_pk)
         for src_pk, targets in counts.iteritems()
       ]
+
+    if isinstance(relationship, types.FunctionType):
+      wrapped = wraps(relationship)(wrapped)
 
     return wrapped

--- a/curious/graph.py
+++ b/curious/graph.py
@@ -112,7 +112,13 @@ def get_related_obj_accessor(rel_obj_descriptor, instance, allow_missing_rel=Fal
 
   def get_related_objects(instances, filters=None):
     queryset = None
-    apply_filters = mk_filter_function(filters)
+
+    # because we can recursively call traverse, after the first call filters
+    # argument is already converted to the result of mk_filter_function
+    if filters is not None and type(filters) == types.FunctionType:
+      apply_filters = filters
+    else:
+      apply_filters = mk_filter_function(filters)
 
     # functioning defining a relationship
     if type(rel_obj_descriptor) in (types.FunctionType, types.MethodType):

--- a/curious/graph.py
+++ b/curious/graph.py
@@ -115,7 +115,7 @@ def get_related_obj_accessor(rel_obj_descriptor, instance, allow_missing_rel=Fal
 
     # because we can recursively call traverse, after the first call filters
     # argument is already converted to the result of mk_filter_function
-    if filters is not None and type(filters) == types.FunctionType:
+    if callable(filters):
       apply_filters = filters
     else:
       apply_filters = mk_filter_function(filters)

--- a/tests/curious_tests/test_api_query.py
+++ b/tests/curious_tests/test_api_query.py
@@ -1,6 +1,7 @@
 import json
 from django.test import TestCase
-from curious import model_registry, CountObject
+from curious import model_registry
+from curious.count import CountObject
 from curious.api import ModelView
 from curious_tests.models import Blog, Entry, Person
 import curious_tests.models

--- a/tests/curious_tests/test_count.py
+++ b/tests/curious_tests/test_count.py
@@ -1,0 +1,72 @@
+from django.test import TestCase
+
+from curious.count import CountObject
+
+from .test_custom_model import MyModel
+
+
+class TestCountObject(TestCase):
+
+  def test_properties(self):
+    self.assertEqual(CountObject(3).value, 3)
+    self.assertEqual(CountObject(3).pk, 3)
+    self.assertEqual(CountObject(3).id, 3)
+
+  def test_wrong_type_sets_value_none(self):
+    self.assertEqual(CountObject("three").value, None)
+
+  def test_fetch(self):
+    pks = [
+      "owls",
+      3,
+      "3",
+      "golden shovel",
+      {},
+      11.5,
+      (),
+      -42,
+    ]
+    self.assertEqual([count_obj.value for count_obj in CountObject.fetch(pks)], [
+      None,
+      3,
+      3,
+      None,
+      None,
+      11,
+      None,
+      -42,
+    ])
+
+  def test_fields(self):
+    self.assertEqual(CountObject(3).fields(), ['id', 'value'])
+
+  def test_get(self):
+    count_obj = CountObject(3)
+    for field in ['pk'] + count_obj.fields():
+      self.assertEqual(count_obj.get(field), 3)
+
+  def test_wrapper(self):
+
+    def example_rel(nodes, filters=None):
+      related = []
+      for node in nodes:
+        related.extend([
+          (MyModel(node.pk + 'a'), node.pk),
+          (MyModel(node.pk + 'b'), node.pk),
+          (MyModel(node.pk + 'a'), node.pk),
+        ])
+
+      return related
+
+    # Make sure our relationship function works as expected
+    self.assertEqual(
+      [(target.pk, src_pk) for target, src_pk in example_rel([MyModel(1)])],
+      [('mymy1a', 'my1'), ('mymy1b', 'my1'), ('mymy1a', 'my1')],
+    )
+
+    # The count function should work the same way, just counting by unique IDs
+    wrapped_rel = CountObject.count_wrapper(example_rel)
+    self.assertEqual(
+      [(target.value, src_pk) for target, src_pk in wrapped_rel([MyModel(1)])],
+      [(2, 'my1')],
+    )

--- a/tests/curious_tests/test_managers.py
+++ b/tests/curious_tests/test_managers.py
@@ -17,15 +17,27 @@ class TestModelRegistry(TestCase):
   def test_register(self):
     self.model_registry.register(models.Person)
 
-    self.assertEqual([['curious_tests__Person']], [self.model_registry.model_names])
+    self.assertItemsEqual(['curious_tests__Person'], self.model_registry.model_names)
 
   def test_register_abstract(self):
     self.model_registry.register(models.Person)
     self.model_registry.register(models.LivingThing)
 
-    self.assertEqual([['curious_tests__Person']], [self.model_registry.model_names])
+    self.assertEqual(['curious_tests__Person'], self.model_registry.model_names)
 
   def test_unregister(self):
     self.model_registry.register(models.Person)
     self.model_registry.unregister('Person')
-    self.assertEqual([[]], [self.model_registry.model_names])
+    self.assertEqual([], self.model_registry.model_names)
+
+  def test_test_special_models(self):
+    model_registry = ModelRegistry(special_models=(models.Person,))
+    self.assertEqual(['curious_tests__Person'], model_registry.model_names)
+
+    # Clear by itself should not remove it
+    self.model_registry.clear()
+    self.assertEqual(['curious_tests__Person'], model_registry.model_names)
+
+    # Clear with force shouldnot remove it
+    self.model_registry.clear(force=True)
+    self.assertEqual([], self.model_registry.model_names)


### PR DESCRIPTION
This works by creating a virtual CountObject model, with counts as its value

These changes allow using a `__count` syntax to return the `CountObject` model

Examples:
```
Molecule(3332) Molecule.fragment_set___count
Molecule(3332) Molecule.sequences__count
```

Replaces #10 

Resolves internal issue BC-469.

